### PR TITLE
feat: usually we don't need api for local models.

### DIFF
--- a/src/parsedOptions.ts
+++ b/src/parsedOptions.ts
@@ -53,9 +53,13 @@ export function parseOptions(options: ExtensionOptions): ParsedOptions {
   const modelProvider = parseCustomModelUrl(model);
 
   // API key
-  const key = options.apikey.trim();
-  if (!key || key.length === 0)
+  let key = options.apikey.trim();
+  if (options.model === "Custom Model" && (!key || key.length === 0)) {
+    key = "***";
+  }
+  if (!key || key.length === 0) {
     throw new Error("Settings error: missing API key");
+  }
   modelProvider.apiKey = key;
 
   // Tone


### PR DESCRIPTION
The custom model requires an API key, although it is often not needed. I decided to temporarily ignore it to avoid breaking the main code. Maybe you can make better solution. Just throw the error without being friendly here, imho.